### PR TITLE
Fixes naming of blob storage docker service.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 version: '3'
 services:
-  blob_storage:
+  blobstorage:
     image: minio/minio
     command: server /data
     environment:
@@ -36,7 +36,7 @@ services:
       CELERY_BROKER_URL: amqp://rabbit-user:rabbit-password@workflow_queue/api-queue
       S3_ACCESS_KEY_ID: minio_access_key
       S3_SECRET_ACCESS_KEY: minio123
-      S3_ENDPOINT_URL: http://blob_storage:9000
+      S3_ENDPOINT_URL: http://blobstorage:9000
     volumes:
       - ../openfido-workflow-service:/opt/app:delegated
     ports:
@@ -44,7 +44,7 @@ services:
     depends_on:
       - workflow_db
       - workflow_queue
-      - blob_storage
+      - blobstorage
   workflow_worker:
     build:
       context: ../openfido-workflow-service
@@ -55,7 +55,7 @@ services:
       WORKER_API_SERVER: http://workflow_service:5001
       S3_ACCESS_KEY_ID: minio_access_key
       S3_SECRET_ACCESS_KEY: minio123
-      S3_ENDPOINT_URL: http://blob_storage:9000
+      S3_ENDPOINT_URL: http://blobstorage:9000
     env_file:
       - .worker-env
     volumes:
@@ -69,7 +69,7 @@ services:
     depends_on:
       - workflow_queue
       - workflow_service
-      - blob_storage
+      - blobstorage
   auth_db:
     image: postgres:11
     environment:
@@ -94,7 +94,7 @@ services:
       - "6002:5000"
     depends_on:
       - auth_db
-      - blob_storage
+      - blobstorage
   app_db:
     image: postgres:11
     environment:
@@ -112,7 +112,7 @@ services:
       SQLALCHEMY_DATABASE_URI: postgresql://postgres:dev-password@app_db/appservice
       S3_ACCESS_KEY_ID: minio_access_key
       S3_SECRET_ACCESS_KEY: minio123
-      S3_ENDPOINT_URL: http://blob_storage:9000
+      S3_ENDPOINT_URL: http://blobstorage:9000
       AUTH_HOSTNAME: http://auth_service:5000
       WORKFLOW_HOSTNAME: http://workflow_service:5000
     volumes:
@@ -122,5 +122,5 @@ services:
     depends_on:
       - app_db
       - auth_service
-      - blob_storage
+      - blobstorage
       - workflow_service


### PR DESCRIPTION
The '_' causes the failed 'by name' routing and the 'no such buckets'
errors.