### PR TITLE
Fixes bad matching of last-run logic.

### DIFF
--- a/app/pipelines/queries.py
+++ b/app/pipelines/queries.py
@@ -62,11 +62,9 @@ def find_latest_organization_pipeline_run(organization_pipeline_id):
     return (
         OrganizationPipelineRun.query.join(OrganizationPipeline)
         .filter(
-            and_(
-                OrganizationPipelineRun.organization_pipeline_id
-                == OrganizationPipeline.id,
-                OrganizationPipeline.is_deleted == False,
-            )
+            OrganizationPipelineRun.organization_pipeline_id
+            == organization_pipeline_id,
+            OrganizationPipeline.is_deleted == False,
         )
         .order_by(OrganizationPipelineRun.created_at.desc())
         .first()

--- a/tests/pipelines/test_services.py
+++ b/tests/pipelines/test_services.py
@@ -153,12 +153,26 @@ def test_fetch_pipelines_bad_workflow_response(app, organization_pipeline):
 
 @patch("app.pipelines.services.fetch_pipeline_run")
 @patch("app.pipelines.services.requests.post")
-def test_fetch_pipelines_no_runs(post_mock, mock_runs, app, organization_pipeline):
-
+def test_fetch_pipelines_bad_workflow_json(
+    post_mock, mock_runs, app, organization_pipeline
+):
     mock_runs.return_value = None
     pipeline_list = [
         {"uuid": organization_pipeline.pipeline_uuid, "name": "name 1"},
         {"uuid": "12345", "name": "name 2"},
+    ]
+    post_mock().json.return_value = pipeline_list
+
+    with pytest.raises(ValueError):
+        fetch_pipelines(ORGANIZATION_UUID)
+
+
+@patch("app.pipelines.services.fetch_pipeline_run")
+@patch("app.pipelines.services.requests.post")
+def test_fetch_pipelines_no_runs(post_mock, mock_runs, app, organization_pipeline):
+    mock_runs.return_value = None
+    pipeline_list = [
+        {"uuid": organization_pipeline.pipeline_uuid, "name": "name 1"},
     ]
     post_mock().json.return_value = pipeline_list
 
@@ -167,7 +181,6 @@ def test_fetch_pipelines_no_runs(post_mock, mock_runs, app, organization_pipelin
             "uuid": organization_pipeline.uuid,
             "name": "name 1",
         },
-        {"uuid": "12345", "name": "name 2"},
     ]
 
     assert fetch_pipelines(ORGANIZATION_UUID) == expected_result


### PR DESCRIPTION
Several times I ran into an issue where the 'last run' logic would fail
if there are no runs in a OrganizationPipeline - turned out to be an
issue with the query.py -- but I refactored and hopefully simplified the
services layer as well.

The error would look something like:

![](https://files.slack.com/files-pri/T025H1AG2-F01EC5E3YQ5/screen_shot_2020-11-10_at_10.42.04_am.png)
